### PR TITLE
@mzikherman: Implement a full text, re-rendering filter

### DIFF
--- a/assets/stylesheets/footer.styl
+++ b/assets/stylesheets/footer.styl
@@ -1,0 +1,4 @@
+.footer
+  margin 40px auto
+  border-top 2px solid gray-lighter-color
+  text-align center

--- a/assets/stylesheets/index.styl
+++ b/assets/stylesheets/index.styl
@@ -9,26 +9,8 @@
 @import 'base'
 @import 'team'
 @import 'member'
-
-// Assorted...
-.hidden
-  display none
-
-.search-navigation
-  position fixed
-  top 0
-  right 0
-  left 0
-  padding 10px 40px
-  background-color rgba(white, 0.90)
-  force-hardware-acceleration()
-  > input
-    border-color transparify(gray-lighter-color, black)
-
-.footer
-  margin 40px auto
-  border-top 2px solid gray-lighter-color
-  text-align center
+@import 'search'
+@import 'footer'
 
 // Media queries
 @import 'mobile'

--- a/assets/stylesheets/search.styl
+++ b/assets/stylesheets/search.styl
@@ -1,0 +1,37 @@
+header-height = 70px
+
+.search
+  display flex
+  height header-height
+  align-items center
+  position fixed
+  top 0
+  right 0
+  left 0
+  padding 0 20px
+  background-color rgba(white, 0.90)
+  force-hardware-acceleration()
+  > input
+    border-color transparify(gray-lighter-color, black)
+
+.results
+  display none
+  position fixed
+  top header-height
+  right 0
+  bottom 0
+  left 0
+  background-color white
+  border-top 2px solid purple-color
+  overflow-y auto
+  -webkit-overflow-scrolling touch
+
+.is-visually-hidden
+  position absolute
+  overflow hidden
+  clip rect(0 0 0 0)
+  height 1px
+  width 1px
+  margin -1px
+  padding 0
+  border 0

--- a/public/javascripts/index.js
+++ b/public/javascripts/index.js
@@ -1,47 +1,27 @@
 $(function() {
   'use strict';
 
-  $('.js-search').on('input', function(e) {
-    var searchText = $(this).val();
+  var threshold, $results, $members;
 
-    // Show all teams, all subteams, all members.
-    $('.member, subteam-name, .team').each(function(index) {
-      $(this).removeClass('hidden');
+  threshold = 30;
+  $results = $('.js-results');
+  $members = $('.js-member');
+
+  $('.js-search').on('input', function() {
+    var query, $matches;
+
+    query = $(this).val().toLowerCase();
+    $matches = $members.filter(function() {
+      if (this.textContent.toLowerCase().indexOf(query) >= 0) return $(this);
     });
 
-    if (!searchText.length) return;
+    if (threshold >= $matches.length) {
+      var $rendered;
 
-    // Find any members whose names don't match, and hide them.
-    $('.member').filter(function(index) {
-      return $(this).attr('data-name').toLowerCase().indexOf(searchText.toLowerCase()) == -1;
-    }).each(function(index) {
-      $(this).addClass('hidden');
-    });
-
-    // Find any teams that have no visible members, and hide them.
-    $('.team').filter(function(index) {
-      return $(this).children('.team-members').children(':not(.hidden)').length === 0;
-    }).each(function(index) {
-      $(this).addClass('hidden');
-    });
-
-    // Hide all subteams
-    $('h2.subteam-name').each(function(index) {
-      $(this).addClass('hidden');
-    });
-
-    // Find subteams belonging to visible members
-    var subteams = $('.member:not(.hidden)').map(function(index) {
-      return $(this).attr('data-subteam');
-    }).filter(function(index) {
-      return $(this).length > 0;
-    });
-
-    // For ever subteam of a visible member, show it.
-    for (i = 0; i < subteams.length; i++) {
-      var header = $('h2:contains(' + subteams[i] + ')').first();
-      header.removeClass('hidden');
+      $rendered = $('<div class="team-members"></div>').html($matches.clone());
+      $results.html($rendered).show();
+    } else {
+      $results.empty().hide();
     }
-
   });
 });

--- a/views/index.jade
+++ b/views/index.jade
@@ -1,11 +1,14 @@
 extends layout
 
 block body
-  header.search-navigation
+  header.search
     input.bordered-input.is-block.js-search(
       size='30'
       placeholder='Search'
     )
+
+  .results.js-results
+    //- Rendered client-side
 
   .teams: for team in teams
     .team

--- a/views/partials/member.jade
+++ b/views/partials/member.jade
@@ -1,4 +1,9 @@
-.member( data-name= member.name, data-subteam= member.subteam )
+.member.js-member
+  .is-visually-hidden
+    //- Any text we want to query on but not display
+    = team.name
+    = subteam.subteam
+
   a.member-headshot(
     style='background-image: url(' + crop(member.headshot, {}) + ');'
     href= member.email.replace('@', '')


### PR DESCRIPTION
Closes https://github.com/artsy/team-navigator/issues/14

![filter-members](https://cloud.githubusercontent.com/assets/112297/9820807/53d667a0-5884-11e5-8ee5-c9cf3638cdf6.gif)

For a while I was trying to do the whole show/hide thing with parent divs and it was just a mess. It's sooooooo much easier and more user friendly to render this as an overlay.
