### PR TITLE
Add editor typing support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,3 +9,4 @@ ARTSY_URL=xxx
 SESSION_SECRET=xxx
 SESSION_KEY=xxx
 PRIVILEGED_USER_IDS=xxx,xxx,xxx
+NODE_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules
 dump.rdb
 public/stylesheets
+.vscode/typings
+.vscode/.browse*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,17 +1,26 @@
 {
     "version": "0.2.0",
     "configurations": [
-    {
-        "name": "Attach To npm",
-        "type": "node",
-        "request": "attach",
-        "port": 5858,
-        "address": "localhost",
-        "restart": false,
-        "sourceMaps": false,
-        "outDir": null,
-        "localRoot": "${workspaceRoot}",
-        "remoteRoot": null
-    }
+        {
+            "name": "Attach",
+            "type": "node",
+            "request": "attach",
+            "port": 5858,
+            "address": "localhost",
+            "restart": false,
+            "sourceMaps": false,
+            "outDir": null,
+            "localRoot": "${workspaceRoot}",
+            "remoteRoot": null
+        },
+        {
+            "name": "Attach to Process",
+            "type": "node",
+            "request": "attach",
+            "processId": "${command.PickProcess}",
+            "port": 5858,
+            "sourceMaps": false,
+            "outDir": null
+        }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+    {
+        "name": "Attach To npm",
+        "type": "node",
+        "request": "attach",
+        "port": 5858,
+        "address": "localhost",
+        "restart": false,
+        "sourceMaps": false,
+        "outDir": null,
+        "localRoot": "${workspaceRoot}",
+        "remoteRoot": null
+    }
+    ]
+}

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: node_modules/.bin/nodemon index.js
+web: node_modules/.bin/nodemon index.js --debug --debug-brk=5858
 redis: redis-server
 assets: node_modules/.bin/stylus -u nib --watch assets/stylesheets --out public/stylesheets

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=759670
+	// for the documentation about the jsconfig.json format
+	"compilerOptions": {
+		"target": "es6",
+		"module": "commonjs",
+		"allowSyntheticDefaultImports": true
+	},
+	"exclude": [
+		"node_modules",
+		"bower_components",
+		"jspm_packages",
+		"tmp",
+		"temp"
+	]
+}

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,26 @@
+{
+  "resolution": {
+    "main": ".vscode/typings"
+  },
+  "globalDependencies": {
+    "body-parser": "registry:dt/body-parser#0.0.0+20160619023215",
+    "cookie-parser": "registry:dt/cookie-parser#1.3.4+20160316155526",
+    "cookie-session": "registry:dt/cookie-session#2.0.0-alpha.1+20160317120654",
+    "express": "registry:dt/express#4.0.0+20160708185218",
+    "jade": "registry:dt/jade#0.0.0+20160316155526",
+    "lodash": "registry:dt/lodash#4.14.0+20160802150749",
+    "moment": "registry:dt/moment#2.8.0+20160316155526",
+    "morgan": "registry:dt/morgan#1.7.0+20160524142355",
+    "passport": "registry:dt/passport#0.2.0+20160720063208",
+    "qs": "registry:dt/qs#6.2.0+20160707010053",
+    "redis": "registry:dt/redis#0.12.1+20160728132028",
+    "request": "registry:dt/request#0.0.0+20160726020908",
+    "stylus": "registry:dt/stylus#0.0.0+20160317120654"
+  },
+  "globalDevDependencies": {
+    "mocha": "registry:dt/mocha#2.2.5+20160720003353",
+    "rewire": "registry:dt/rewire#2.5.1+20160317120654",
+    "should": "registry:dt/should#8.1.1+20160608082854",
+    "sinon": "registry:dt/sinon#1.16.0+20160517064723"
+  }
+}


### PR DESCRIPTION
This is the minimum that I can do to get auto-complete and local debugging support inside VS Code.

This works by using [typings](https://github.com/typings/typings) to provide metadata and documentation about modules and functions throughout the npm dependencies. This is then read by VS Code to provide inline docs:

![screen shot 2016-08-05 at 9 05 52 am](https://cloud.githubusercontent.com/assets/49038/17437495/058d67f4-5aec-11e6-82df-e769dd214e41.png)

![screen shot 2016-08-05 at 9 05 26 am](https://cloud.githubusercontent.com/assets/49038/17437498/07ab19aa-5aec-11e6-86ea-01bec4376e6c.png)

![screen shot 2016-08-05 at 9 09 05 am](https://cloud.githubusercontent.com/assets/49038/17437548/4646c54c-5aec-11e6-89be-a514f4fea877.png)

To use it, I would recommend installing [Typings Auto Installer](https://marketplace.visualstudio.com/items?itemName=jvitor83.typings-autoinstaller) to have it keep the project up to date.

### Reasons for files existing

`.vscode/launch.json` sets up the debugger
`jsconfig.json` [provides metadata for the js symbolification](https://code.visualstudio.com/docs/runtimes/nodejs#_adding-a-jsconfigjson-configuration-file) for the debugger, and the jump-to for symbols
`typings.json` makes sure that the typings definitions go into something gitignored, and keeps some automated metadata around