### PR TITLE
@orta: Filter team members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dump.rdb
 public/stylesheets
 .vscode/typings
 .vscode/.browse*
+npm-debug.log

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -2,15 +2,18 @@ import Lokka from 'lokka'
 import Transport from 'lokka-transport-http'
 import tree from 'universal-tree'
 import Index from '../views'
+import { filter, values } from 'lodash'
 
 const api = new Lokka({
-  transport: new Transport(process.env.APP_URL + '/api/member')
+  transport: new Transport(process.env.APP_URL + '/api')
 })
 
 export const state = tree({
   teams: [],
   cities: [],
-  members: []
+  members: [],
+  allMembers: [],
+  curFilter: ''
 })
 
 export const index = async (ctx) => {
@@ -24,11 +27,18 @@ export const index = async (ctx) => {
         floor
         city
         headshot
+        team
       }
     }`)
   )
   state.set('teams', teams)
   state.set('cities', cities)
   state.set('members', members)
+  state.set('allMembers', members)
   ctx.render({ body: Index })
+}
+
+export const filterMembers = async (attrs) => {
+  state.set('curFilter', values(attrs)[0])
+  state.set('members', filter(state.get('allMembers'), attrs))
 }

--- a/app/server.js
+++ b/app/server.js
@@ -5,7 +5,7 @@ import * as models from './models'
 
 const app = new Koa()
 
-router.all('/api/member', graphqlize(models))
+router.all('/api', graphqlize(models))
 app.use(router.routes())
 
 export default app

--- a/app/views/sidebar.js
+++ b/app/views/sidebar.js
@@ -1,6 +1,8 @@
 import veact from 'veact'
-import { state } from '../controllers'
-import { type, mediumMargin, grayRegular, sidebarWidth } from './lib'
+import { state, filterMembers } from '../controllers'
+import {
+  type, mediumMargin, grayRegular, sidebarWidth, purpleRegular
+} from './lib'
 import { assign } from 'lodash'
 
 const view = veact()
@@ -22,6 +24,9 @@ view.styles({
   },
   br: {
     height: mediumMargin
+  },
+  li: {
+    cursor: 'pointer'
   }
 })
 
@@ -29,11 +34,17 @@ view.render(() =>
   div('.container',
     h2('.h2', 'Locations'),
     ul('.ul', state.get('cities').map((city) =>
-      li(city))),
+      li('.li', {
+        onClick: () => filterMembers({ city }),
+        style: { color: city === state.get('curFilter') ? purpleRegular : '' }
+      }, city))),
     br('.br'),
     h2('.h2', 'Teams'),
     ul('.ul', state.get('teams').map((team) =>
-      li(team))))
+      li('.li', {
+        onClick: () => filterMembers({ team }),
+        style: { color: team === state.get('curFilter') ? purpleRegular : '' }
+      }, team))))
 )
 
 export default view()

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ import envify from 'envify'
 
 const { MONGO_URL, PORT } = process.env
 
-// Bundle together client and server app for hot reloading, and,
-// to be implemented, production ready asset bundle serving
+// Bundle together client and server app for hot reloading, and—
+// to be implemented—production ready asset bundle serving
 // when NODE_ENV=production
 const app = module.exports = hotglue({
   relative: __dirname + '/app',


### PR DESCRIPTION
This adds client-side filtering based on team or city categories. Doing client-side stuff is just a matter up making updates to our state tree—which I'll point out more inline.

Sorry for some random cleanup noise as well.

![cap](https://cloud.githubusercontent.com/assets/555859/18496786/c7872d1c-79f6-11e6-8a30-aa562448f5c7.gif)
