### PR TITLE
@orta (cc @wrgoldstein + @sweir27): Image processing, detail view, tests and more

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,4 @@ NODE_ENV=development
 APP_URL=http://localhost:3000
 PORT=3000
 MONGO_URL=mongodb://localhost:27017/team-navigator
-SHEETS_URL=foobar.com
+SHEETS_URL=REPLACE

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2016 Artsy Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+[![Build Status](https://semaphoreci.com/api/v1/projects/94083eb0-a44a-4b7a-a4be-56ddc5758ac4/560485/badge.svg)](https://semaphoreci.com/artsy-it/team-navigator)
+
+# Team Navigator
+
+### Meta
+* __State:__ production
+* __Production:__ [team.artsy.net](https://team.artsy.net/)
+* __CI:__ [Semaphore](https://semaphoreci.com/artsy-it/team-navigator)
+* __Point People:__ [@craigspaeth](https://github.com/craigspaeth), [@orta](https://github.com/orta)
+
+### Set-Up
+
+- Fork Team Navigator to your Github account in the Github UI.
+- Clone your repo locally (substitute your Github username).
+```
+git clone git@github.com:your-github-username/team-navigator.git
+```
+- Install MongoDB
+```
+brew install mongodb
+```
+- Install [NVM](https://github.com/creationix/nvm), [Node](https://nodejs.org/en/), and npm modules.
+```
+brew install nvm
+nvm install 6
+npm install
+```
+- Copy over a .env file and replace all sensitive config, e.g. `SHEETS_URL=REPLACE`,
+with staging config.
+```
+cp .env.example .env
+heroku config --app=team-navigator-staging
+```
+- Start Team Navigator and Mongo
+```
+npm run dev
+```
+- Team Navigator should now be running at http://localhost:3000/
+
+### Testing
+
+We use [standard](https://github.com/feross/standard) for linting. For the best experience it's recommended that you install an inline linter in your text editor, such as [Sublime Linter Standard](https://github.com/Flet/SublimeLinter-contrib-standard), to surface linting issues immediately.
+
+We use [mocha](https://mochajs.org/) for testing. To run the full test suite and linter use `npm test`.
+
+For the best experience writing tests it's recommended you target the suite you're working on in watch mode `npm run mocha -- --watch test/your/tests.js`.

--- a/app/controllers/image.js
+++ b/app/controllers/image.js
@@ -3,13 +3,14 @@ import request from 'superagent'
 
 const cache = {}
 
-export const resizeImg = async (ctx) => {
+export const resizeImg = async (ctx, next) => {
   ctx.set('Content-Type', 'image/jpeg')
   const url = `https://dropbox.com/${ctx.url.replace('img', '')}?raw=1`
   if (cache[url]) {
     ctx.body = cache[url]
   } else {
     ctx.body = request.get(url).pipe(sharp().resize(75))
+    await next()
     cache[url] = await ctx.body.toBuffer()
   }
 }

--- a/app/controllers/image.js
+++ b/app/controllers/image.js
@@ -1,0 +1,15 @@
+import sharp from 'sharp'
+import request from 'superagent'
+
+const cache = {}
+
+export const resizeImg = async (ctx) => {
+  ctx.set('Content-Type', 'image/jpeg')
+  const url = `https://dropbox.com/${ctx.url.replace('img', '')}?raw=1`
+  if (cache[url]) {
+    ctx.body = cache[url]
+  } else {
+    ctx.body = request.get(url).pipe(sharp().resize(75))
+    cache[url] = await ctx.body.toBuffer()
+  }
+}

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -8,20 +8,24 @@ const api = new Lokka({
   transport: new Transport(process.env.APP_URL + '/api')
 })
 
-export const state = tree({
+const treeData = {
   teams: [],
   cities: [],
   members: [],
   allMembers: [],
-  curFilter: ''
-})
+  curFilter: '',
+  member: null
+}
 
-export const index = async (ctx) => {
+export const state = tree(treeData)
+
+export const initData = async (ctx) => {
   const { teams, cities, members } = await ctx.bootstrap(() =>
     api.query(`{
       teams
       cities
       members {
+        _id
         name
         title
         floor
@@ -31,10 +35,33 @@ export const index = async (ctx) => {
       }
     }`)
   )
+  state.set(treeData)
   state.set('teams', teams)
   state.set('cities', cities)
   state.set('members', members)
   state.set('allMembers', members)
+}
+
+export const index = async (ctx) => {
+  await initData(ctx)
+  ctx.render({ body: Index })
+}
+
+export const show = async (ctx) => {
+  const { member } = await ctx.bootstrap(() =>
+    api.query(`{
+      member(_id: "${ctx.params.id}") {
+        name
+        title
+        floor
+        city
+        headshot
+        team
+      }
+    }`)
+  )
+  await initData(ctx)
+  state.set('member', member)
   ctx.render({ body: Index })
 }
 

--- a/app/models/member.js
+++ b/app/models/member.js
@@ -23,12 +23,16 @@ export const member = model('member', {
   notes: string()
 })
 
-export const teams = query('teams', array().items(string()), async (ctx, next) => {
-  ctx.res.teams = await db.members.distinct('team')
-  await next()
-})
+export const teams = query('teams', array().items(string()),
+  async (ctx, next) => {
+    ctx.res.teams = await db.members.distinct('team')
+    await next()
+  }
+)
 
-export const cities = query('cities', array().items(string()), async (ctx, next) => {
-  ctx.res.cities = await db.members.distinct('city')
-  await next()
-})
+export const cities = query('cities', array().items(string()),
+  async (ctx, next) => {
+    ctx.res.cities = await db.members.distinct('city')
+    await next()
+  }
+)

--- a/app/models/sync.js
+++ b/app/models/sync.js
@@ -18,5 +18,5 @@ export default mutation('sync', string(), async (ctx, next) => {
   const parsed = await convert(res.text)
   const members = parsed.map((obj) => mapKeys(obj, (v, k) => camelCase(k)))
   await Promise.all(members.map((member) => db.members.save(member)))
-  ctx.res.sync = 'succesful'
+  ctx.res.sync = 'success'
 })

--- a/app/router.js
+++ b/app/router.js
@@ -1,7 +1,7 @@
 import unikoa from 'unikoa'
 import bootstrap from 'unikoa-bootstrap'
 import render from 'unikoa-react-render'
-import { index, state } from './controllers'
+import { index, state, show } from './controllers'
 import Head from './views/head'
 
 const router = unikoa()
@@ -12,5 +12,6 @@ router.use(render({
   subscribe: (cb) => state.on('update', cb)
 }))
 router.get('/', index)
+router.get('/:id', show)
 
 export default router

--- a/app/server.js
+++ b/app/server.js
@@ -2,10 +2,12 @@ import Koa from 'koa'
 import { graphqlize } from 'joiql-mongo'
 import router from './router'
 import * as models from './models'
+import { resizeImg } from './controllers/image'
 
 const app = new Koa()
 
 router.all('/api', graphqlize(models))
+router.get('/img/*', resizeImg)
 app.use(router.routes())
 
 export default app

--- a/app/views/head.js
+++ b/app/views/head.js
@@ -48,6 +48,10 @@ table {
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+a {
+  color: black;
+  text-decoration: none;
 }`
 const fontsUrl = '//fast.fonts.net/cssapi/' +
   'f7f47a40-b25b-44ee-9f9c-cfdfc8bb2741.css'

--- a/app/views/member-group.js
+++ b/app/views/member-group.js
@@ -3,11 +3,12 @@ import {
   type, smallMargin, mediumMargin, largeMargin, grayRegular, ellipsisize
 } from './lib'
 import { assign } from 'lodash'
+import url from 'url'
 
 const view = veact()
 
 const headshotSize = 75
-const { div, h1, p } = view.els()
+const { div, h1, p, a } = view.els()
 
 view.styles({
   h1: assign(
@@ -32,7 +33,8 @@ view.styles({
     display: 'inline-block',
     verticalAlign: 'top',
     marginLeft: 10,
-    width: `calc(100% - ${headshotSize + 10}px)`
+    width: `calc(100% - ${headshotSize + 10}px)`,
+    paddingRight: mediumMargin
   }),
   wrapper: {
     marginBottom: mediumMargin,
@@ -45,16 +47,18 @@ view.styles({
 view.render(({ members, title }) =>
   div('.container',
     h1('.h1', title),
-    div(members.map((member) =>
-      div('.wrapper',
+    div(members.map((member) => {
+      const src = url.parse(member.headshot).pathname
+      return a('.wrapper', { href: member._id },
         div('.headshot', {
-          style: { backgroundImage: `url(${member.headshot})` }
+          style: { backgroundImage: `url(/img${src})` }
         }),
         div('.text',
           p(member.name),
           p('.title', member.title),
           p(`${member.city}, Fl. ${member.floor}`))
-        ))))
+        )
+    })))
 )
 
 export default view()

--- a/app/views/sidebar/index.js
+++ b/app/views/sidebar/index.js
@@ -1,0 +1,32 @@
+import veact from 'veact'
+import Member from './member'
+import LocationsTeams from './locations-teams'
+import { state } from '../../controllers'
+import { mediumMargin, sidebarWidth } from '../lib'
+
+const view = veact()
+
+const { div, locationsteams, member } = view.els({
+  locationsteams: LocationsTeams,
+  member: Member
+})
+
+view.styles({
+  container: {
+    padding: mediumMargin,
+    width: sidebarWidth,
+    height: '100%',
+    display: 'inline-block',
+    verticalAlign: 'top'
+  }
+})
+
+view.render(() =>
+  div('.container',
+    (() => {
+      if (state.get('member')) return member()
+      else return locationsteams()
+    })())
+)
+
+export default view()

--- a/app/views/sidebar/locations-teams.js
+++ b/app/views/sidebar/locations-teams.js
@@ -1,8 +1,6 @@
 import veact from 'veact'
-import { state, filterMembers } from '../controllers'
-import {
-  type, mediumMargin, grayRegular, sidebarWidth, purpleRegular
-} from './lib'
+import { state, filterMembers } from '../../controllers'
+import { type, mediumMargin, purpleRegular } from '../lib'
 import { assign } from 'lodash'
 
 const view = veact()
@@ -15,13 +13,6 @@ view.styles({
     { marginBottom: 10 }
   ),
   ul: type('garamond', 'body'),
-  container: {
-    padding: mediumMargin,
-    width: sidebarWidth,
-    height: '100%',
-    display: 'inline-block',
-    verticalAlign: 'top'
-  },
   br: {
     height: mediumMargin
   },
@@ -31,7 +22,7 @@ view.styles({
 })
 
 view.render(() =>
-  div('.container',
+  div(
     h2('.h2', 'Locations'),
     ul('.ul', state.get('cities').map((city) =>
       li('.li', {

--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -1,0 +1,23 @@
+import veact from 'veact'
+import { state } from '../../controllers'
+import { type } from '../lib'
+import { assign } from 'lodash'
+
+const view = veact()
+
+const { div, h2, a } = view.els()
+
+view.styles({
+  h2: assign(
+    type('avantgarde', 'smallHeadline'),
+    { marginBottom: 10 }
+  )
+})
+
+view.render(() =>
+  div(
+    a({ href: '/' }, 'Back'),
+    h2('.h2', state.get('member').name))
+)
+
+export default view()

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import { connect } from 'joiql-mongo'
 import hotglue from 'hotglue'
 import babelify from 'babelify'
 import envify from 'envify'
+import path from 'path'
 
 const { MONGO_URL, PORT } = process.env
 
@@ -9,7 +10,7 @@ const { MONGO_URL, PORT } = process.env
 // to be implemented—production ready asset bundle serving
 // when NODE_ENV=production
 const app = module.exports = hotglue({
-  relative: __dirname + '/app',
+  relative: path.join(__dirname, '/app'),
   server: {
     main: 'server.js',
     watch: [

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
-  "name": "team",
+  "name": "team-navigator",
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "node": "NODE_PATH=$NODE_PATH:./lib node -r dotenv/config -r babel-core/register",
-    "start": "concurrently 'npm run node .' 'mongod'"
+    "node": "node -r dotenv/config -r babel-core/register",
+    "mocha": "NODE_ENV=test mocha -r dotenv/config -r babel-core/register -r should",
+    "lint": "standard",
+    "test": "npm run lint && npm run mocha test/*",
+    "dev": "concurrently 'npm run node .' 'mongod'",
+    "start": "node -r babel-core/register ."
   },
   "standard": {
     "parser": "babel-eslint"
@@ -14,6 +18,13 @@
       "es2015",
       "stage-3"
     ],
+    "env": {
+      "test": {
+        "plugins": [
+          "rewire"
+        ]
+      }
+    },
     "plugins": [
       "transform-runtime"
     ]
@@ -39,11 +50,20 @@
     "lokka-transport-http": "^1.4.0",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
+    "sharp": "^0.16.0",
     "superagent": "^2.2.0",
     "unikoa": "0.0.1",
     "unikoa-bootstrap": "0.0.2",
     "unikoa-react-render": "0.0.4",
     "universal-tree": "0.0.2",
     "veact": "0.0.5"
+  },
+  "devDependencies": {
+    "babel-plugin-rewire": "^1.0.0",
+    "cheerio": "^0.22.0",
+    "mocha": "^3.0.2",
+    "should": "^11.1.0",
+    "sinon": "^1.17.6",
+    "standard": "^8.1.0"
   }
 }

--- a/test/controllers/image.js
+++ b/test/controllers/image.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+import sinon from 'sinon'
+import controller, { resizeImg } from '../../app/controllers/image'
+
+describe('resizeImg', () => {
+  let ctx, request, sharp, cache
+
+  beforeEach(() => {
+    // Stub cache
+    cache = {}
+    controller.__set__('cache', cache)
+    // Stub superagent
+    request = {}
+    request.get = sinon.stub().returns(request)
+    request.pipe = sinon.stub().returns(request)
+    request.toBuffer = sinon.stub()
+    controller.__set__('request', request)
+    // Stub sharp
+    sharp = sinon.stub()
+    sharp.returns({ resize: sinon.stub().returns(sharp) })
+    controller.__set__('sharp', sharp)
+    // Stub context
+    ctx = { set: sinon.stub(), url: 'foo', body: '' }
+  })
+
+  it('converts a local url into a resized request to dropbox', async () => {
+    ctx.url = 'img/s/a/amy.jpg'
+    await resizeImg(ctx)
+    request.get.args[0][0].should.equal('https://dropbox.com//s/a/amy.jpg?raw=1')
+  })
+
+  it('returns the sharp resized img as the body', async () => {
+    const stream = sinon.stub()
+    stream.toBuffer = sinon.stub()
+    request.pipe.returns(stream)
+    await resizeImg(ctx)
+    request.pipe.calledWith(sharp).should.be.ok()
+    ctx.body.should.equal(stream)
+  })
+
+  it('returns images from the cache', async () => {
+    ctx.url = 'img/s/a/amy.jpg'
+    cache['https://dropbox.com//s/a/amy.jpg?raw=1'] = 'foobar'
+    await resizeImg(ctx)
+    ctx.body.should.equal('foobar')
+    request.get.called.should.not.be.ok()
+  })
+})

--- a/test/controllers/image.js
+++ b/test/controllers/image.js
@@ -3,7 +3,7 @@ import sinon from 'sinon'
 import controller, { resizeImg } from '../../app/controllers/image'
 
 describe('resizeImg', () => {
-  let ctx, request, sharp, cache
+  let ctx, next, request, sharp, cache
 
   beforeEach(() => {
     // Stub cache
@@ -19,13 +19,14 @@ describe('resizeImg', () => {
     sharp = sinon.stub()
     sharp.returns({ resize: sinon.stub().returns(sharp) })
     controller.__set__('sharp', sharp)
-    // Stub context
+    // Stub middleware args
     ctx = { set: sinon.stub(), url: 'foo', body: '' }
+    next = sinon.stub()
   })
 
   it('converts a local url into a resized request to dropbox', async () => {
     ctx.url = 'img/s/a/amy.jpg'
-    await resizeImg(ctx)
+    await resizeImg(ctx, next)
     request.get.args[0][0].should.equal('https://dropbox.com//s/a/amy.jpg?raw=1')
   })
 
@@ -33,7 +34,7 @@ describe('resizeImg', () => {
     const stream = sinon.stub()
     stream.toBuffer = sinon.stub()
     request.pipe.returns(stream)
-    await resizeImg(ctx)
+    await resizeImg(ctx, next)
     request.pipe.calledWith(sharp).should.be.ok()
     ctx.body.should.equal(stream)
   })
@@ -41,7 +42,7 @@ describe('resizeImg', () => {
   it('returns images from the cache', async () => {
     ctx.url = 'img/s/a/amy.jpg'
     cache['https://dropbox.com//s/a/amy.jpg?raw=1'] = 'foobar'
-    await resizeImg(ctx)
+    await resizeImg(ctx, next)
     ctx.body.should.equal('foobar')
     request.get.called.should.not.be.ok()
   })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,18 @@
+import { merge } from 'lodash'
+import { renderToString } from 'react-dom/server'
+import { createElement } from 'react'
+import cheerio from 'cheerio'
+
+export const fixture = (type, attrs) =>
+  merge({}, {
+    member: {
+      name: 'Orta',
+      title: 'Badass',
+      headshot: 'http://foobar.com/img/1.jpg',
+      floor: 25,
+      city: 'NYC'
+    }
+  }[type], attrs)
+
+export const render = (Component, props = {}) =>
+  cheerio.load(renderToString(createElement(Component, props)))

--- a/test/models/sync.js
+++ b/test/models/sync.js
@@ -1,0 +1,29 @@
+/* eslint-env mocha */
+import sinon from 'sinon'
+import sync from '../../app/models/sync'
+
+describe('Sync', () => {
+  let ctx, next, request, db, resolve
+
+  beforeEach(() => {
+    // Stub middleware arguments
+    ctx = { req: { mutation: { sync: {} } }, res: {} }
+    next = sinon.stub()
+    // Stub superagent
+    request = {}
+    request.get = sinon.stub().returns(request)
+    sync.__set__('request', request)
+    // Stub mongojs
+    db = { members: { save: sinon.stub().returns(Promise.resolve()) } }
+    sync.__set__('db', db)
+    // Helper to run resolve function
+    resolve = () => sync.middleware[0](ctx, next)
+  })
+
+  it('syncs a csv of team members into mongo documents', async () => {
+    request.get.returns(Promise.resolve({ text: 'name,title\nOrta,Badass' }))
+    await resolve()
+    db.members.save.calledWith({ name: 'Orta', title: 'Badass' }).should.be.ok()
+    ctx.res.sync.should.equal('success')
+  })
+})

--- a/test/views/member-group.js
+++ b/test/views/member-group.js
@@ -1,0 +1,20 @@
+/* eslint-env mocha */
+import { fixture, render } from '../helpers'
+import MemberGroup from '../../app/views/member-group'
+
+describe('MemberGroup', () => {
+  let props
+
+  beforeEach(() => {
+    props = {
+      members: [fixture('member')],
+      title: 'O'
+    }
+  })
+
+  it('renders an alphbetically grouped list of members', async () => {
+    const $ = render(MemberGroup, props)
+    $('h1').text().should.equal('O')
+    $('a').text().should.equal('OrtaBadassNYC, Fl. 25')
+  })
+})

--- a/test/views/members.js
+++ b/test/views/members.js
@@ -1,0 +1,17 @@
+/* eslint-env mocha */
+import Baobab from 'baobab'
+import { fixture, render } from '../helpers'
+import Members from '../../app/views/members'
+
+describe('Members', () => {
+  let state
+
+  beforeEach(() => {
+    state = new Baobab({ members: [fixture('member')] })
+    Members.__set__('state', state)
+  })
+
+  it('renders list of member groups', async () => {
+    render(Members).html().should.containEql('Orta')
+  })
+})


### PR DESCRIPTION
Sorry for the large PR, I should have broken this up better but I was attacking things in a scatter-brained manner and ended up concurrently getting to this stopping point.

Quick reminder—this is our v2 branch of Team Navigator being used as an experimenting grounds for the React + GraphQL stack I demoed at Lunch & Learn currently code named "Mural". This PR includes a couple different additions, such as...

### Image processing

For the sake of expirmenting, this uses [sharp](https://github.com/lovell/sharp) to embed an on-the-fly image processor inside the Koa app. It provides an endpoint `/img/:id/:name.jpg` that `<img>` tags point to. This endpoint will request the original high-res image from Dropbox, stream the raw contents of the jpg to sharp, sharp then resizes the image down to a 75x75px thumbnail, and we finally cache the thumbnail buffer in Node memory.

This is a silly experiment for the sake of seeing how implementing more server-side intense logic would look in this stack. Doing this, for one, has the caveat that storing JPEGs in Node memory could quickly hit Heroku's limit. However, ironically for this use case I believe it's a decent solution given that 1. sharp uses [libvips](https://github.com/jcupitt/libvips) which is really good at compressing our tiny thumbnails at ~4KB a piece 2. we're using streams that shouldn't hold on to a ton of memory during the processing 3. caching the file in the Node server means no need for network hops to a caching service, or adding complexity in syncing up with a CDN. So all in all I'm betting this doesn't cause enough of a memory issue to matter, and the end user experience is pretty decent given libvips compression + local caching 🙏 

That said, in a serious app we'd just use Gemini 😛 

###  Documentation and Tests

Adding a README.md, LICENSE, a suite of tests for some base MVC coverage. Model tests are pulling out the middleware functions, stubbing dependencies using a Babel plugin that adds [rewire](https://github.com/jhnns/rewire) to `import`s (we have this in Metaphysics), and using [Mocha](https://mochajs.org/), [Sinon](http://sinonjs.org/), and [Should](https://shouldjs.github.io/) to round out the testing tools family. I'm also adding [standard](https://github.com/feross/standard) to `npm test`. I've outlined in the README how installing an in-IDE/text-editor linter and using mocha's `--watch` feature will be the most pleasant way to deal with testing/linting too.

### Member detail view

Started the boilerplate for an individual member's view. Which still needs a lot of work. This just adds the controller functionality and renders their name in the sidebar. As pictured below.

![cap](https://cloud.githubusercontent.com/assets/555859/18811644/554b3116-8285-11e6-863b-005de776f81c.gif)

### Finally

Phew! That's a fair bit to chew on. Let me know if you have any questions!