### PR TITLE
Add manager and list of teams to member display

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -30,6 +30,7 @@ export const initData = async (ctx) => {
         city
         headshot
         team
+        reportsTo
       }
     }`)
   )

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -30,6 +30,7 @@ export const initData = async (ctx) => {
         city
         headshot
         team
+        productTeam
         reportsTo
       }
     }`)

--- a/app/views/lib.js
+++ b/app/views/lib.js
@@ -63,3 +63,14 @@ export const ellipsisize = () => ({
   overflow: 'hidden',
   textOverflow: 'ellipsis'
 })
+
+export const borderedButton = () => ({
+  display: 'block',
+  color: graySemibold,
+  borderTop: `1px solid ${graySemibold}`,
+  borderBottom: `1px solid ${graySemibold}`,
+  paddingTop: '15px',
+  paddingBottom: '15px',
+  marginTop: '30px',
+  marginBottom: '30px'
+})

--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -5,13 +5,20 @@ import { assign } from 'lodash'
 
 const view = veact()
 
-const { div, h2, a, p } = view.els()
+const { div, h2, h3, a, p } = view.els()
 
 view.styles({
   h2: assign(
     type('garamond', 'body'),
     {
       marginBottom: 10,
+      fontWeight: 'bold'
+    }
+  ),
+  h3: assign(
+    type('garamond', 'body'),
+    {
+      marginTop: 10,
       fontWeight: 'bold'
     }
   ),
@@ -37,7 +44,10 @@ view.render(() =>
     p(`${state.get('member').city}, Fl. ${state.get('member').floor}`),
     div({
       onClick: () => filterMembersByTeam(state.get('member').team)
-    }, `View ${state.get('member').name}'s team`))
+    }, `View ${state.get('member').name}'s team`),
+    h3('.h3', 'Reports to'),
+    p(state.get('member').reportsTo)
+  )
 )
 
 export default view()

--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -45,6 +45,9 @@ view.render(() =>
     div({
       onClick: () => filterMembersByTeam(state.get('member').team)
     }, `View ${state.get('member').name}'s team`),
+    h3('.h3', 'Teams'),
+    p(state.get('member').team),
+    p(state.get('member').productTeam),
     h3('.h3', 'Reports to'),
     p(state.get('member').reportsTo)
   )

--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -1,6 +1,6 @@
 import veact from 'veact'
 import { state, filterMembersByTeam } from '../../controllers'
-import { type, graySemibold } from '../lib'
+import { type, graySemibold, borderedButton } from '../lib'
 import { assign } from 'lodash'
 
 const view = veact()
@@ -24,14 +24,13 @@ view.styles({
   ),
   backButton: assign(
     type('avantgarde', 'body'),
+    borderedButton()
+  ),
+  teamButton: assign(
+    type('avantgarde', 'body'),
+    borderedButton(),
     {
-      color: graySemibold,
-      paddingTop: '15px',
-      paddingBottom: '15px',
-      borderTop: `1px solid ${graySemibold}`,
-      borderBottom: `1px solid ${graySemibold}`,
-      marginBottom: '30px',
-      display: 'block'
+      cursor: 'pointer'
     }
   )
 })
@@ -42,7 +41,7 @@ view.render(() =>
     h2('.h2', state.get('member').name),
     p(state.get('member').title),
     p(`${state.get('member').city}, Fl. ${state.get('member').floor}`),
-    div({
+    div('.teamButton', {
       onClick: () => filterMembersByTeam(state.get('member').team)
     }, `View ${state.get('member').name}'s team`),
     h3('.h3', 'Teams'),

--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -1,6 +1,6 @@
 import veact from 'veact'
 import { state, filterMembersByTeam } from '../../controllers'
-import { type, graySemibold, borderedButton } from '../lib'
+import { type, borderedButton } from '../lib'
 import { assign } from 'lodash'
 
 const view = veact()

--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -24,7 +24,10 @@ view.styles({
   ),
   backButton: assign(
     type('avantgarde', 'body'),
-    borderedButton()
+    borderedButton(),
+    {
+      marginTop: 0
+    }
   ),
   teamButton: assign(
     type('avantgarde', 'body'),

--- a/app/views/sidebar/search.js
+++ b/app/views/sidebar/search.js
@@ -13,6 +13,7 @@ view.styles({
     {
       width: '100%',
       border: `2px solid ${grayRegular}`,
+      marginBottom: '30px',
       paddingLeft: '5px',
       outline: 'none'
     }

--- a/app/views/sidebar/search.js
+++ b/app/views/sidebar/search.js
@@ -13,7 +13,6 @@ view.styles({
     {
       width: '100%',
       border: `2px solid ${grayRegular}`,
-      marginBottom: '30px',
       paddingLeft: '5px',
       outline: 'none'
     }


### PR DESCRIPTION
This newbie Mural PR does a few simple things:

* add sections for **Teams** and **Reports To** to the member view

* refactor some css into a shared style

* use shared style to style the "view team" button


<img width="835" alt="team" src="https://cloud.githubusercontent.com/assets/140521/19973153/cda4bc96-a1ba-11e6-91b5-6bc0cfe5060f.png">