### PR TITLE
Add link to reports to member

### DIFF
--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -50,13 +50,14 @@ view.render(() =>
     h3('.h3', 'Teams'),
     p(state.get('member').team),
     p(state.get('member').productTeam),
-    div(state.get('member').reportsTo ?
-      div(
-        h3('.h3', 'Reports to'),
-        a('.wrapper',
-          { href: `/member/${find(state.get('allMembers'), { 'name': state.get('member').reportsTo })._id}`
-        }, state.get('member').reportsTo)
-      ) : ''
+    div(state.get('member').reportsTo
+      ? div(
+          h3('.h3', 'Reports to'),
+          a('.wrapper',
+            { href: `/member/${find(state.get('allMembers'), { 'name': state.get('member').reportsTo })._id}`
+          }, state.get('member').reportsTo)
+        )
+      : ''
     )
   )
 )

--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -1,7 +1,7 @@
 import veact from 'veact'
 import { state, filterMembersByTeam } from '../../controllers'
 import { type, borderedButton } from '../lib'
-import { assign } from 'lodash'
+import { assign, find } from 'lodash'
 
 const view = veact()
 
@@ -50,8 +50,14 @@ view.render(() =>
     h3('.h3', 'Teams'),
     p(state.get('member').team),
     p(state.get('member').productTeam),
-    h3('.h3', 'Reports to'),
-    p(state.get('member').reportsTo)
+    div(state.get('member').reportsTo ?
+      div(
+        h3('.h3', 'Reports to'),
+        a('.wrapper', 
+          { href: `/member/${find(state.get('allMembers'), { 'name': state.get('member').reportsTo })._id}`
+        }, state.get('member').reportsTo)
+      ) : ''
+    )
   )
 )
 

--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -53,7 +53,7 @@ view.render(() =>
     div(state.get('member').reportsTo ?
       div(
         h3('.h3', 'Reports to'),
-        a('.wrapper', 
+        a('.wrapper',
           { href: `/member/${find(state.get('allMembers'), { 'name': state.get('member').reportsTo })._id}`
         }, state.get('member').reportsTo)
       ) : ''


### PR DESCRIPTION
Fixes an issue of displaying "Reports to" for members who don't have that field, and adds a link to the "Reports to" member that brings up their sidebar view.  

The href is unfortunately a lil verbose, because `state.get('member').reportsTo` returns a string, not the member object.  Also, I wonder if there's a way to use a single div instead of the doubly nested thing I ended up with...