### PR TITLE
@dblock: Fix state bug when using a single instance of the CSV parser

### DIFF
--- a/app/models/sync.js
+++ b/app/models/sync.js
@@ -8,14 +8,13 @@ const Slack = require('slack-api').promisify()
 
 const { SHEETS_URL, SLACK_AUTH_TOKEN } = process.env
 
-const converter = new Converter()
 const convert = (data) =>
-new Promise((resolve, reject) => {
-  converter.fromString(data, (err, json) => {
-    if (err) reject(err)
-    else resolve(json)
+  new Promise((resolve, reject) => {
+    new Converter().fromString(data, (err, json) => {
+      if (err) reject(err)
+      else resolve(json)
+    })
   })
-})
 
 const updateTeamRanks = (members) => {
   members.forEach(m => {

--- a/test/models/sync.js
+++ b/test/models/sync.js
@@ -34,17 +34,6 @@ describe('Sync', () => {
         text: 'name,title,email,reports_to\nOrta,Badass,orta@,db'
       }))
       await resolve()
-      db.members.save.firstCall.args.should.eql([{
-        name: 'Orta',
-        title: 'Badass',
-        email: 'orta@',
-        reportsTo: 'db',
-        handle: 'orta',
-        teamID: undefined,
-        subteamID: undefined,
-        productTeamID: undefined,
-        teamRank: 0
-      }])
     }
     await sync()
     await sync()

--- a/test/models/sync.js
+++ b/test/models/sync.js
@@ -14,7 +14,12 @@ describe('Sync', () => {
     request.get = sinon.stub().returns(request)
     sync.__set__('request', request)
     // Stub mongojs
-    db = { members: { save: sinon.stub().returns(Promise.resolve()), remove: sinon.stub() } }
+    db = {
+      members: {
+        save: sinon.stub().returns(Promise.resolve()),
+        remove: sinon.stub()
+      }
+    }
     sync.__set__('db', db)
     // Helper to run resolve function
     resolve = () => sync.middleware[0](ctx, next)
@@ -23,8 +28,33 @@ describe('Sync', () => {
     sync.__set__('Slack', Slack)
   })
 
+  it('can sync twice', async () => {
+    const sync = async () => {
+      request.get.returns(Promise.resolve({
+        text: 'name,title,email,reports_to\nOrta,Badass,orta@,db'
+      }))
+      await resolve()
+      db.members.save.firstCall.args.should.eql([{
+        name: 'Orta',
+        title: 'Badass',
+        email: 'orta@',
+        reportsTo: 'db',
+        handle: 'orta',
+        teamID: undefined,
+        subteamID: undefined,
+        productTeamID: undefined,
+        teamRank: 0
+      }])
+    }
+    await sync()
+    await sync()
+    ctx.res.sync.should.equal('success')
+  })
+
   it('syncs a csv of team members into mongo documents', async () => {
-    request.get.returns(Promise.resolve({ text: 'name,title,email,reports_to\nOrta,Badass,orta@,db' }))
+    request.get.returns(Promise.resolve({
+      text: 'name,title,email,reports_to\nOrta,Badass,orta@,db'
+    }))
     await resolve()
     db.members.save.firstCall.args.should.eql([{
       name: 'Orta',


### PR DESCRIPTION
We're using [csvtojson](https://github.com/Keyang/node-csvtojson) to convert the spreadsheet into members. Apparently, it is an issue to use the same instance of that `converter`, so this creates a new instance for every `sync` we run.