### PR TITLE
[Fix] Ensure a profile exists before asking for further details about a user

### DIFF
--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -158,7 +158,7 @@ view.render(() => {
         member.timeZone ? p('.list', `Time Zone: ${member.timeZone}`) : ''
       ]),
       // Social Related
-       profile.facebook_url || profile.twitter_url || profile.instagram_url || profile.website_url
+       profile && profile.facebook_url || profile.twitter_url || profile.instagram_url || profile.website_url
          ? div('.section', [
            profile.facebook_url ? p('.list', a('.grey', {href: profile.facebook_url}, `Facebook: ${profile.facebook}`)) : '',
            profile.twitter ? p('.list', a('.grey', {href: profile.twitter_url}, `Twitter: @${profile.twitter}`)) : '',


### PR DESCRIPTION
It's possible that a user could not have a profile in Slack, and so we need to account of that being null in the db.

![screen shot 2017-04-04 at 13 30 54](https://cloud.githubusercontent.com/assets/49038/24656571/ff3588d8-193a-11e7-806a-387fa26978cd.png)