### PR TITLE
Handles slack profiles being null correctly

### DIFF
--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -158,7 +158,7 @@ view.render(() => {
         member.timeZone ? p('.list', `Time Zone: ${member.timeZone}`) : ''
       ]),
       // Social Related
-       profile && profile.facebook_url || profile.twitter_url || profile.instagram_url || profile.website_url
+      profile && (profile.facebook_url || profile.twitter_url || profile.instagram_url || profile.website_url)
          ? div('.section', [
            profile.facebook_url ? p('.list', a('.grey', {href: profile.facebook_url}, `Facebook: ${profile.facebook}`)) : '',
            profile.twitter ? p('.list', a('.grey', {href: profile.twitter_url}, `Twitter: @${profile.twitter}`)) : '',


### PR DESCRIPTION
Sometimes we get emails being set up wrong in the spreadsheet, which means the link in email address between the slack profile and team nav profile doesn't align. 

This should be handled without crashing the an individual's page, so I've fixed up the logic here. 