### PR TITLE
Apply the exif-based autorotation before creating a thumbnail

### DIFF
--- a/app/controllers/image.js
+++ b/app/controllers/image.js
@@ -13,7 +13,7 @@ export const resizeImg = async (ctx, next) => {
     ctx.body = readFileSync(localPath)
   } else {
     const writableStream = createWriteStream(localPath)
-    const resizer = sharp().resize(100)
+    const resizer = sharp().rotate().resize(100)
 
     // Allow passing directly to the response, but also write to a tmp file
     ctx.body = request.get(url).pipe(resizer).on('data', (data) => {


### PR DESCRIPTION
If you add a rotate int the image pipeline without an able, it uses the exif data to make everything align right.

Looks good when compared to production 👍 