### PR TITLE
Add a start method so heroku doesn't crash repeatedly

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "yarn lint && yarn mocha test/*",
     "dev": "concurrently 'yarn v2' 'yarn v3'",
     "build": "react-app-rewired build",
-    "start": ""
+    "start": "npm run v2"
   },
   "homepage": "/v3",
   "engines": {


### PR DESCRIPTION
Team nav is crashing a lot because heroku is trying to run `npm start` but it's currently empty... This updates it to run `v2` which is what it was doing previously. 

@orta maybe we can catch up tomorrow on what it should be running. 