### PR TITLE
Add link to request Team Navigator update via Hivy

### DIFF
--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -40,6 +40,10 @@ view.styles({
       fontWeight: 'bold'
     }
   ),
+  p: {
+    fontSize: "14px",
+    lineHeight: "24px"
+  },
   backButton: assign(
     type('avantgarde', 'body'),
     borderedButton(),
@@ -233,7 +237,13 @@ view.render(() => {
               )
           )
         : ''
-      )
+      ),
+      div([
+        h3('.h3', 'Something missing or incorrect?'),
+        p('.p', [
+          a(assign({ href: `https://artsy.hivyapp.com/catalog?initialItemId=IfRG9X35cn`, style: { display: 'block' } }, extenalLinkProperties), "Request an update via Hivy", externalLinkIcon)
+        ])
+      ])
 
     )
 }


### PR DESCRIPTION
Links to a new Hivy ticket type to request an update for information shown in Team Navigator.

![2018-11-30-165905_706x161_scrot](https://user-images.githubusercontent.com/123595/49317130-40555600-f4c1-11e8-82e0-b8ccf92c7b1d.png)
