### PR TITLE
Have organization break down into teams, fix team member count

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -161,6 +161,7 @@ export const showOrg = async (ctx) => {
   state.set('members', orgMembers)
 
   state.set('title', `Members of ${org}`)
+  state.set('format', 'subteams')
   ctx.render({ body: Index })
 }
 

--- a/app/views/sidebar/search.js
+++ b/app/views/sidebar/search.js
@@ -9,6 +9,17 @@ const artsyLogo = readFileSync(path.join(__dirname, './artsy-logo.svg'))
 const view = veact()
 
 const { div, a, input } = view.els()
+const filteredNumOfEmployees = () => {
+  let seen = new Set();
+  for (var member of state.get('allMembers')) {
+    if (member.title.includes('Contributor to The Art Genome Project')) {
+      console.log(member.name, member.title);
+      continue;
+    }
+    seen.add(member.email);
+  }
+  return seen.size;
+}
 
 view.styles({
   searchWrapper: {
@@ -40,7 +51,7 @@ view.render(() =>
   div('.searchWrapper',
     a('.navItem', { href: `/`, dangerouslySetInnerHTML: { __html: artsyLogo } }),
     input('.input', {
-      placeholder: `Search ${state.get('allMembers').length} team members`,
+      placeholder: `Search ${filteredNumOfEmployees()} team members`,
       onChange: (e) => searchMembers(e.target.value)
     })
   )

--- a/app/views/sidebar/search.js
+++ b/app/views/sidebar/search.js
@@ -13,7 +13,6 @@ const filteredNumOfEmployees = () => {
   let seen = new Set();
   for (var member of state.get('allMembers')) {
     if (member.title.includes('Contributor to The Art Genome Project')) {
-      console.log(member.name, member.title);
       continue;
     }
     seen.add(member.email);


### PR DESCRIPTION
These were two issues brought up during the people tech meeting:
- Clicking on organizations in the menu should display people categorized by teams
- Number in search bar should be correct:
  - Leadership team is counted twice
  - Genomers should not count towards total

Not a javascript dev by any means so appreciate any feedback if there's a better way to do this!