### PR TITLE
Update "Request an update" link to target Managed by Q page

### DIFF
--- a/app/views/sidebar/member.js
+++ b/app/views/sidebar/member.js
@@ -241,7 +241,7 @@ view.render(() => {
       div([
         h3('.h3', 'Something missing or incorrect?'),
         p('.p', [
-          a(assign({ href: `https://artsy.hivyapp.com/catalog?initialItemId=IfRG9X35cn`, style: { display: 'block' } }, extenalLinkProperties), "Request an update via Hivy", externalLinkIcon)
+          a(assign({ href: `https://dashboard.managedbyq.com/tasks/artsy/catalog?initialItemId=IfRG9X35cn`, style: { display: 'block' } }, extenalLinkProperties), "Request an update via Managed by Q ", externalLinkIcon)
         ])
       ])
 


### PR DESCRIPTION
Hivy was [purchased by Managed by Q last year][purchase] and they have are now completing the integration of their products.

Redirects from the `hivyapp.com` domain seem to work but this eagerly updates the link to avoid breakage in the future.

[purchase]: https://blog.managedbyq.com/creating-a-world-class-office-experience-with-hivy