### PR TITLE
Use 'team' role for authorization instead of 'admin'

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If the example is out of date, that's fine, go look at the member model and conv
 
 ## Optional ENV vars
 
-`EXCEPTION_USER_IDS` - lets you add non-artsy admins to the app, by adding their user IDs to the environment
+`EXCEPTION_USER_IDS` - lets you add non-artsy users to the app, by adding their user IDs to the environment
 `NO_SYNCING` - skips the syncing of data on startup
 
 ### Testing

--- a/app/auth.js
+++ b/app/auth.js
@@ -17,8 +17,8 @@ export function validArtsyEmail (email) {
   return /@artsymail.com$/.test(email) || /@artsy.net$/.test(email)
 }
 
-export function isUserAdmin (user) {
-  return user.type === 'Admin' || user.roles.indexOf('admin') !== -1
+export function isUserAuthorized (user) {
+  return user.roles.indexOf('team') !== -1
 }
 
 export function isOnExceptionList (user) {
@@ -28,7 +28,7 @@ export function isOnExceptionList (user) {
 export function authenticateWithUser (ctx) {
   return ctx && ctx.isAuthenticated() &&
        validArtsyEmail(ctx.state.user.email) &&
-       isUserAdmin(ctx.state.user) || isOnExceptionList(ctx.state.user)
+       isUserAuthorized(ctx.state.user) || isOnExceptionList(ctx.state.user)
 }
 
 export function isNodeFetchSelf (ctx) {


### PR DESCRIPTION
Related to [PLATFORM-1863](https://artsyproduct.atlassian.net/browse/PLATFORM-1863) and dependent on https://github.com/artsy/gravity/pull/12781.

Let's not require that all employees have the powerful `admin` role just to access company resources.

Admittedly, I'm making this change a little blind. I had some local `lint`-ing and testing failures, and I'm not even sure if this app has a staging environment or how it's deployed. Any insight there?